### PR TITLE
Infranode Chart Updates

### DIFF
--- a/charts/infranode/Chart.yaml
+++ b/charts/infranode/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: "1.1.0"
 description: A Helm chart for OPES Infrastructure Node
 name: infranode
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/opespe/helm-charts/charts/infranode
 icon: https://avatars3.githubusercontent.com/u/48919572?s=100&v=4

--- a/charts/infranode/scripts/boot-producer.sh
+++ b/charts/infranode/scripts/boot-producer.sh
@@ -47,10 +47,17 @@ function _term() {
 }
 
 function start_nodeos {
-  nodeos $* --genesis-json $config_dir/genesis.json --config-dir $config_dir
+  nodeos $* --genesis-json $config_dir/genesis.json --config-dir $config_dir --data-dir /eosio-data
 }
 
 init_config
+
+if [[ -r /eosio-data/upgrade.sh ]]; then
+  echo "Found upgrade script. Running upgrade script..."
+  source /eosio-data/upgrade.sh
+  echo "Upgrade script complete. Removing upgrade script."
+  rm -rf /eosio-data/upgrade.sh
+fi
 
 trap _term SIGTERM
 

--- a/charts/infranode/templates/secrets.yaml
+++ b/charts/infranode/templates/secrets.yaml
@@ -30,7 +30,6 @@ stringData:
     plugin = eosio::net_plugin
     plugin = eosio::http_plugin
     plugin = eosio::history_api_plugin
-    blocks-dir = /eosio-data/blocks
     max-clients = {{ .Values.maxClients }}
     max-transaction-time = {{ .Values.maxTransactionTime }}
     abi-serializer-max-time-ms = {{ .Values.abiSerializerMaxTimeMs }}


### PR DESCRIPTION
* Addresses issue with persisting blockchain state files between pod restarts that causes node to replay block log everytime.
* Adding functionality to inject upgrade scripts on node startup by placing a file called `upgrade.sh` under the `/eosio-data` directory.